### PR TITLE
Prevent double execution of saveUploads

### DIFF
--- a/behaviors/FileBehavior.php
+++ b/behaviors/FileBehavior.php
@@ -49,6 +49,7 @@ class FileBehavior extends Behavior
             }
         }
         rmdir($userTempDir);
+        unset($_FILES);
     }
 
     public function deleteUploads($event)


### PR DESCRIPTION
It may happen that after the model has been created/updated you need to save it again.
Without this patch the saveUploads is executed again on the same POST data, and the behavior tries to save the files twice.