### PR TITLE
check for file exists in module before detaching, avoids exception.

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -157,7 +157,9 @@ class Module extends \yii\base\Module
         $file = File::findOne(['id' => $id]);
         if (empty($file)) return false;
         $filePath = $this->getFilesDirPath($file->hash) . DIRECTORY_SEPARATOR . $file->hash . '.' . $file->type;
-
-        return unlink($filePath) && $file->delete();
+        
+        // this is the important part of the override.
+        // the original methods doesn't check for file_exists to be 
+        return file_exists($filePath) ? unlink($filePath) && $file->delete() : $file->delete();
     }
 }


### PR DESCRIPTION
The file would throw an exception before if the file does not exist in the Module->detachFile() method. This corrects that with a simple file_exists first.