### PR TITLE
creates a URL to get a file path, to use images in PDF

### DIFF
--- a/src/controllers/FileController.php
+++ b/src/controllers/FileController.php
@@ -55,6 +55,12 @@ class FileController extends Controller
         return Yii::$app->response->sendFile($filePath, "$file->name.$file->type");
     }
 
+    public function actionFilePath($id)
+    {
+        $file = File::findOne(['id' => $id]);
+        return $this->getModule()->getFilesDirPath($file->hash) . DIRECTORY_SEPARATOR . $file->hash . '.' . $file->type;
+    }
+
     public function actionDelete($id)
     {
         if ($this->getModule()->detachFile($id)) {


### PR DESCRIPTION
This fix is needed, as to use this file controller in MDPF, we simply need the file path for the image. A new route is created in FileController that is essentially the same as actionDownload, but it stops short of returning the object, and returns the file path instead.