### PR TITLE
Allow file controller do download inline and adjust preview configs

### DIFF
--- a/src/behaviors/FileBehavior.php
+++ b/src/behaviors/FileBehavior.php
@@ -124,7 +124,7 @@ class FileBehavior extends Behavior
         }
 
         foreach ($this->getFiles() as $index => $file) {
-            if(str_contains($file->mime,"image")
+            if(str_contains($file->mime,"image"))
            {
                $initialPreviewConfig[] = [
                    'type'=>'image',

--- a/src/behaviors/FileBehavior.php
+++ b/src/behaviors/FileBehavior.php
@@ -125,25 +125,44 @@ class FileBehavior extends Behavior
 
         foreach ($this->getFiles() as $index => $file) {
            if(str_contains($file->mime,"image"))
-           {
-               $initialPreviewConfig[] = [
-                   'type'=>'image',
+            {
+                $initialPreviewConfig[] = [
                     'caption' => "$file->name.$file->type",
                     'url' => Url::toRoute(['/attachments/file/delete',
-                        'id' => $file->id
-                    ]),
+                    'id' => $file->id])
                 ];
-           }
-           else
-           {
-                 $initialPreviewConfig[] = [
-                   'type'=>$file->type,
+            }
+            elseif(str_contains($file->mime,"text")){
+                $initialPreviewConfig[] = [
+                'type'=> "text",
+                'caption' => "$file->name.$file->type",
+                'url' => Url::toRoute(['/attachments/file/delete',
+                'id' => $file->id])
+            ];
+            }
+            elseif(str_contains($file->mime,"video")){
+                $initialPreviewConfig[] = [
+                'type'=> "video",
+                'caption' => "$file->name.$file->type",
+                'url' => Url::toRoute(['/attachments/file/delete',
+                'id' => $file->id])
+            ];
+            }
+            elseif(str_contains($file->mime,"doc")||str_contains($file->mime,".ppt")||str_contains($file->mime,".xls")){
+                $initialPreviewConfig[] = [
+                'type'=> "office",
+                'caption' => "$file->name.$file->type",
+                'url' => Url::toRoute(['/attachments/file/delete',
+                'id' => $file->id])
+            ];
+            }
+            else{
+                $initialPreviewConfig[] = [
+                    'type'=> $file->type,
                     'caption' => "$file->name.$file->type",
                     'url' => Url::toRoute(['/attachments/file/delete',
-                        'id' => $file->id
-                    ]),
+                    'id' => $file->id])
                 ];
-            
             }
         }
         return $initialPreviewConfig;

--- a/src/behaviors/FileBehavior.php
+++ b/src/behaviors/FileBehavior.php
@@ -102,15 +102,7 @@ class FileBehavior extends Behavior
         }
 
         foreach ($this->getFiles() as $file) {
-            if (substr($file->mime, 0, 5) === 'image') {
-                $initialPreview[] = Html::img($file->getUrl(), ['class' => 'file-preview-image']);
-            } else {
-                $initialPreview[] = Html::beginTag('div', ['class' => 'file-preview-other']) .
-                    Html::beginTag('h2') .
-                    Html::tag('i', '', ['class' => 'glyphicon glyphicon-file']) .
-                    Html::endTag('h2') .
-                    Html::endTag('div');
-            }
+             $initialPreview[] =$file->getUrl(true);
         }
 
         return $initialPreview;
@@ -132,13 +124,27 @@ class FileBehavior extends Behavior
         }
 
         foreach ($this->getFiles() as $index => $file) {
-            $initialPreviewConfig[] = [
-                'caption' => "$file->name.$file->type",
-                'url' => Url::toRoute(['/attachments/file/delete',
-                    'id' => $file->id
-                ]),
-            ];
-        }
+            if(str_contains($file->mime,"image")
+           {
+               $initialPreviewConfig[] = [
+                   'type'=>'image',
+                    'caption' => "$file->name.$file->type",
+                    'url' => Url::toRoute(['/attachments/file/delete',
+                        'id' => $file->id
+                    ]),
+                ];
+           }
+            else
+            {
+                 $initialPreviewConfig[] = [
+                   'type'=>$file->type,
+                    'caption' => "$file->name.$file->type",
+                    'url' => Url::toRoute(['/attachments/file/delete',
+                        'id' => $file->id
+                    ]),
+                ];
+            
+            }
 
         return $initialPreviewConfig;
     }

--- a/src/behaviors/FileBehavior.php
+++ b/src/behaviors/FileBehavior.php
@@ -124,7 +124,7 @@ class FileBehavior extends Behavior
         }
 
         foreach ($this->getFiles() as $index => $file) {
-            if(str_contains($file->mime,"image"))
+           if(str_contains($file->mime,"image"))
            {
                $initialPreviewConfig[] = [
                    'type'=>'image',
@@ -134,8 +134,8 @@ class FileBehavior extends Behavior
                     ]),
                 ];
            }
-            else
-            {
+           else
+           {
                  $initialPreviewConfig[] = [
                    'type'=>$file->type,
                     'caption' => "$file->name.$file->type",
@@ -145,7 +145,7 @@ class FileBehavior extends Behavior
                 ];
             
             }
-
+        }
         return $initialPreviewConfig;
     }
 }

--- a/src/components/AttachmentsInput.php
+++ b/src/components/AttachmentsInput.php
@@ -40,6 +40,8 @@ class AttachmentsInput extends Widget
         FileHelper::removeDirectory($this->getModule()->getUserDirPath()); // Delete all uploaded files in past
 
         $this->pluginOptions = array_replace($this->pluginOptions, [
+            'initialPreviewFileType'=> 'image',  
+            'initialPreviewAsData'=> 'true', //let kartik deal with the previews!
             'uploadUrl' => Url::toRoute('/attachments/file/upload'),
             'uploadAsync' => false
         ]);

--- a/src/controllers/FileController.php
+++ b/src/controllers/FileController.php
@@ -47,12 +47,12 @@ class FileController extends Controller
         }
     }
 
-    public function actionDownload($id)
+    public function actionDownload($id,$inline=false)
     {
         $file = File::findOne(['id' => $id]);
         $filePath = $this->getModule()->getFilesDirPath($file->hash) . DIRECTORY_SEPARATOR . $file->hash . '.' . $file->type;
 
-        return Yii::$app->response->sendFile($filePath, "$file->name.$file->type");
+        return Yii::$app->response->sendFile($filePath, "$file->name.$file->type",['inline'=>$inline]);
     }
 
     public function actionDelete($id)

--- a/src/models/File.php
+++ b/src/models/File.php
@@ -70,9 +70,9 @@ class File extends ActiveRecord
         ];
     }
 
-    public function getUrl()
+    public function getUrl($inline = false)
     {
-        return Url::to(['/attachments/file/download', 'id' => $this->id]);
+        return Url::to(['/attachments/file/download', 'id' => $this->id,'inline'=>$inline]);
     }
 
     public function getPath()


### PR DESCRIPTION
When getting file urls, we can't use them in previews since they directly download in the file controller.  We have to wrap them in img tags for images, or a fake container with a file image for other types.  If we allow the user the option of downloading inline,
 `$file->getUrl('inline'=true)` 
we can use the function to generate urls that are compatible with Kartiks File Input option 
`'initialPreviewAsData'=> 'true',`

This means that the file input widget can create the preview code automatically by setting the "type" parameter based on the file mime type in initialPreviewConfig.

This pull request adds an optional parameter to getUrl, and handles that in the filecontroller.

It also updates the built in AttachmentsInput to generate the attachments input with better previewConfigs (image, pdf, txt, office, video)


 